### PR TITLE
Add minimal synthwave portfolio page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,11 @@
-# Start Bootstrap - Freelancer | Blazor | Kentico Kontent
+# Jason Thomas Portfolio
 
-## Blazor port
-This web template is a [Blazor](https://dotnet.microsoft.com/apps/aspnet/web-apps/client) port of the bootstrap [Freelancer](http://startbootstrap.com/template-overviews/freelancer/) template. It demonstrates the usage of the [Kentico Kontent Delivery SDK for .NET](https://github.com/Kentico/delivery-sdk-net) in a client-hosted Blazor app. In fact, all data is stored in Kentico Kontent. It also shows how to use JS Interop, event binding, one-way, two-way databinding, linker configuration and other features of [ASP.NET Core Blazor](https://dotnet.microsoft.com/apps/aspnet/web-apps/client).
+This repository contains a simple static HTML/CSS portfolio site. Customize `index.html` and `style.css` with your own content.
 
-### Freelancer web template - Original work
-[Freelancer](http://startbootstrap.com/template-overviews/freelancer/) is a one page freelancer portfolio theme for [Bootstrap](http://getbootstrap.com/) created by [Start Bootstrap](http://startbootstrap.com/). This theme features several content sections, a responsive portfolio grid, window modals for each portfolio item, and a contact form.
+## Development
 
+No build step is required. Open `index.html` in a browser to preview the site.
 
-## Preview
+## License
 
-[![Freelancer Preview](https://assets.startbootstrap.com/img/screenshots/themes/freelancer.high.webp)](https://petrsvihlik.github.io/StartBootstrap.Freelancer.Blazor/)
-
-**[View Live Preview](https://petrsvihlik.github.io/StartBootstrap.Freelancer.Blazor/)**
-
-
-## Download and Installation
-
-- Install the latest preview of the [.NET Core SDK](https://docs.microsoft.com/en-us/aspnet/core/blazor/get-started?view=aspnetcore-3.0&tabs=visual-studio)
-  - (and [VS 2019 Preview](https://visualstudio.microsoft.com/vs/preview/) with [Blazor extension](https://marketplace.visualstudio.com/items?itemName=aspnet.blazor))
-- `dotnet run`
-- [`http://localhost:56625/`](http://localhost:56625/)
-
-## Usage
-See https://github.com/BlackrockDigital/startbootstrap-freelancer#usage
-
-
-## Copyright and License
-
-### Original work
-Copyright 2013-2019 Blackrock Digital LLC. Code released under the [MIT](https://github.com/BlackrockDigital/startbootstrap-freelancer/blob/gh-pages/LICENSE) license.
-
-### Blazor port
-Copyright 2019 Petr Svihlik. Code released under the [MIT](https://github.com/petrsvihlik/StartBootstrap.Freelancer.Blazor/blob/master/LICENSE) license.
+This project is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Jason Thomas - Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="site-header">
+    <h1>Jason Thomas</h1>
+    <p class="tagline">Software Developer & Designer</p>
+  </header>
+  <nav class="site-nav">
+    <a href="#about">About</a>
+    <a href="#projects">Projects</a>
+    <a href="#contact">Contact</a>
+  </nav>
+  <main>
+    <section id="about" class="section">
+      <h2>About</h2>
+      <p>Replace this with a short bio describing your skills and experience.</p>
+    </section>
+    <section id="projects" class="section">
+      <h2>Projects</h2>
+      <p>Showcase your work with project descriptions or links.</p>
+    </section>
+    <section id="contact" class="section">
+      <h2>Contact</h2>
+      <p>Provide your preferred contact details or a form.</p>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <small>&copy; 2024 Jason Thomas</small>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,71 @@
+:root {
+  --bg-color: #0d0d0d;
+  --accent: #ff00ff;
+  --accent2: #00d9ff;
+  --text-color: #ffffff;
+  --text-muted: #b3b3b3;
+  --font-main: 'Roboto', sans-serif;
+  --font-accent: 'Orbitron', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-family: var(--font-main);
+  line-height: 1.6;
+  text-align: center;
+}
+
+.site-header {
+  padding: 3rem 1rem 1rem;
+}
+
+.site-header h1 {
+  font-family: var(--font-accent);
+  font-size: 3rem;
+  color: var(--accent);
+}
+
+.tagline {
+  color: var(--accent2);
+  font-weight: 300;
+  margin-top: 0.5rem;
+}
+
+.site-nav {
+  margin: 2rem 0;
+}
+
+.site-nav a {
+  margin: 0 1rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.site-nav a:hover {
+  color: var(--accent2);
+}
+
+.section {
+  padding: 4rem 1rem;
+  border-top: 1px solid #222;
+}
+
+.section h2 {
+  color: var(--accent);
+  margin-bottom: 1rem;
+  font-family: var(--font-accent);
+}
+
+.site-footer {
+  padding: 2rem 1rem;
+  border-top: 1px solid #222;
+  color: var(--text-muted);
+}


### PR DESCRIPTION
## Summary
- Replace repo with static portfolio template
- Add synthwave-inspired HTML/CSS layout
- Update README with usage instructions

## Testing
- `npx -y htmlhint index.html`
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b09b5a8508832fbf050835831c71df